### PR TITLE
Decided multimethods should probably not be written until opennlp 1.5.0 is done right

### DIFF
--- a/src/opennlp/nlp.clj
+++ b/src/opennlp/nlp.clj
@@ -65,7 +65,7 @@
   (if-not (file-exist? modelfile)
     (throw (FileNotFoundException. "Model file does not exist."))
     (with-open [model-stream (FileInputStream. modelfile)]
-      (make-tokenizer (TokenizerModel. modelstream)))))
+      (make-tokenizer (TokenizerModel. model-stream)))))
 
 (defmethod make-tokenizer TokenizerModel
   [model]


### PR DESCRIPTION
This adds the methods for training as they exist in opennlp 1.4.2
