### PR TITLE
use the lang argument in 2 arg arity on train-document-categorization

### DIFF
--- a/src/opennlp/tools/train.clj
+++ b/src/opennlp/tools/train.clj
@@ -146,7 +146,8 @@
 (defn ^DoccatModel train-document-categorization
   "Returns a classification model based on a given training file"
   ([in] (train-document-categorization "en" in 1 100))
-  ([lang in] (train-document-categorization "en" in 1 100))
+  ([lang in] (train-document-categorization lang in 1 100))
+  ([lang in cutoff] (train-document-categorization lang in cutoff 100))
   ([lang in cutoff iterations]
      (with-open [rdr (reader in)]
        (DocumentCategorizerME/train lang


### PR DESCRIPTION
The lang arg wasn't used in [lang in] arity of  `train-document-categorization`, I also added another function to bridge the gap with the full version. 

Cheers and thanks for that library, huge timesaver!
