### PR TITLE
Set the array component type to "String".

### DIFF
--- a/src/opennlp/nlp.clj
+++ b/src/opennlp/nlp.clj
@@ -100,7 +100,7 @@ start and end positions of the span."
   (fn pos-tagger
     [tokens]
     {:pre [(coll? tokens)]}
-    (let [token-array (into-array tokens)
+    (let [token-array (into-array String tokens)
           tagger (POSTaggerME. model *beam-size* *cache-size*)
           tags (.tag tagger token-array)
           probs (seq (.probs tagger))]

--- a/test/opennlp/test/nlp.clj
+++ b/test/opennlp/test/nlp.clj
@@ -26,6 +26,8 @@
          ["Mr." "Smith" "gave" "a" "car" "to" "his" "son" "on" "Friday" "."])))
 
 (deftest pos-tag-test
+  (is (= (pos-tag (tokenize ""))
+         '()))
   (is (= (pos-tag (tokenize "Mr. Smith gave a car to his son on Friday."))
          '(["Mr." "NNP"] ["Smith" "NNP"] ["gave" "VBD"] ["a" "DT"] ["car" "NN"]
              ["to" "TO"] ["his" "PRP$"] ["son" "NN"] ["on" "IN"]


### PR DESCRIPTION
Without this change `(into-array [])` returns an `Object[]` instead of a
`String[]` which is what `.tag` expects, causing:

  java.lang.IllegalArgumentException: No matching method found: tag for class
  opennlp.tools.postag.POSTaggerME
