### PR TITLE
Update project.clj and add type hints for avoiding reflective calls and improving the performance.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.apache.opennlp/opennlp-tools "1.5.3"]
-                 [instaparse "1.4.0"]]
+                 [instaparse "1.4.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]
                    :plugins [[lein-marginalia "0.8.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha6"]]}}
-  :aliases {"all" ["with-profile" "dev,1.5:dev:dev,1.7"]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
+  :aliases {"all" ["with-profile" "dev,1.5:dev:dev,1.7:dev,1.8"]}
   :jvm-opts ["-Xmx2048m"])

--- a/src/opennlp/nlp.clj
+++ b/src/opennlp/nlp.clj
@@ -133,7 +133,7 @@ start and end positions of the span."
            (every? string? tokens)]}
     (let [finder (NameFinderME.
                    model
-                   ^opennlp.tools.namefind.NameContextGenerator feature-generator
+                   ^opennlp.tools.util.featuregen.AdaptiveFeatureGenerator feature-generator
                    (int beam))
           a-tokens (into-array String tokens)
           matches (.find finder a-tokens)

--- a/src/opennlp/nlp.clj
+++ b/src/opennlp/nlp.clj
@@ -20,24 +20,31 @@
 
 ;; OpenNLP property for pos-tagging. Meant to be rebound before
 ;; calling the tagging creators
-(def ^:dynamic *beam-size* 3)
+(def ^:dynamic *beam-size* (int 3))
 
 ;; Caching to use for pos-tagging
-(def ^:dynamic *cache-size* 1024)
+(def ^:dynamic *cache-size* (int 1024))
 
 (defn- opennlp-span-strings
   "Takes a collection of spans and the data they refer to. Returns a list of
   substrings corresponding to spans."
   [span-col data]
   (if (seq span-col)
-    (seq (Span/spansToStrings (into-array span-col)
-                              (if (string? data) data (into-array data))))
+    (if (string? data)
+      (seq
+        (Span/spansToStrings
+          #^"[Lopennlp.tools.util.Span;" (into-array span-col)
+          ^String data))
+      (seq
+        (Span/spansToStrings
+          #^"[Lopennlp.tools.util.Span;" (into-array span-col)
+          #^"[Ljava.lang.String;" (into-array data))))
     []))
 
 (defn- to-native-span
   "Take an OpenNLP span object and return a pair [i j] where i and j are the
 start and end positions of the span."
-  [span]
+  [^Span span]
   (nspan/make-span (.getStart span) (.getEnd span) (.getType span)))
 
 (defmulti make-sentence-detector
@@ -96,13 +103,13 @@ start and end positions of the span."
     (make-pos-tagger (POSModel. model-stream))))
 
 (defmethod make-pos-tagger POSModel
-  [model]
+  [^POSModel model]
   (fn pos-tagger
     [tokens]
     {:pre [(coll? tokens)]}
     (let [token-array (into-array String tokens)
-          tagger (POSTaggerME. model *beam-size* *cache-size*)
-          tags (.tag tagger token-array)
+          tagger (POSTaggerME. model ^int *beam-size* ^int *cache-size*)
+          tags (.tag tagger #^"[Ljava.lang.String;" token-array)
           probs (seq (.probs tagger))]
       (with-meta
         (map vector tokens tags)
@@ -119,17 +126,20 @@ start and end positions of the span."
     (make-name-finder (TokenNameFinderModel. model-stream))))
 
 (defmethod make-name-finder TokenNameFinderModel
-  [model & {:keys [feature-generator beam] :or {beam *beam-size*}}]
+  [^TokenNameFinderModel model & {:keys [feature-generator beam] :or {beam *beam-size*}}]
   (fn name-finder
     [tokens & contexts]
     {:pre [(seq tokens)
            (every? string? tokens)]}
-    (let [finder (NameFinderME. model feature-generator beam)
+    (let [finder (NameFinderME.
+                   model
+                   ^opennlp.tools.namefind.NameContextGenerator feature-generator
+                   (int beam))
           a-tokens (into-array String tokens)
           matches (.find finder a-tokens)
           probs (seq (.probs finder))]
       (with-meta
-        (distinct (Span/spansToStrings matches a-tokens))
+        (distinct (Span/spansToStrings #^"[Lopennlp.tools.util.Span;" matches #^"[Ljava.lang.String;" a-tokens))
         {:probabilities probs
          :spans (map to-native-span matches)}))))
 
@@ -228,7 +238,7 @@ start and end positions of the span."
     {:pre [(coll? tokens)
            (every? string? tokens)]}
     (-> (DictionaryDetokenizer. model)
-        (TokenSample. (into-array String tokens))
+        (TokenSample. #^"[Ljava.lang.String;" (into-array String tokens))
         (.getText))))
 
 (defn parse-categories [outcomes-string outcomes]
@@ -248,12 +258,12 @@ start and end positions of the span."
     (make-document-categorizer (DoccatModel. model-stream))))
 
 (defmethod make-document-categorizer DoccatModel
-  [model]
+  [^DoccatModel model]
   (fn document-categorizer
     [text]
     {:pre [(string? text)]}
     (let [categorizer (DocumentCategorizerME. model)
-          outcomes (.categorize categorizer text)]
+          outcomes (.categorize categorizer ^String text)]
       (with-meta
         {:best-category (.getBestCategory categorizer outcomes)}
         {:probabilities (parse-categories

--- a/src/opennlp/treebank.clj
+++ b/src/opennlp/treebank.clj
@@ -144,7 +144,7 @@
   (let [line (strip-parens line)
         results (StringBuffer.)
         parse-num 1]
-    (.show (first (ParserTool/parseLine line parser parse-num)) results)
+    (.show ^Parse (first (ParserTool/parseLine line parser parse-num)) results)
     (str results)))
 
 
@@ -196,8 +196,8 @@
 
 (defn print-child
   "Given a child, parent and start, print out the child parse."
-  [c p start]
-  (let [^Span s (.getSpan c)]
+  [^Parse c ^Parse p start]
+  (let [s (.getSpan c)]
     (if (< @start (.getStart s))
       (print (subs (.getText p) start (.getStart s))))
     (print-parse c)
@@ -225,7 +225,7 @@
 (defn add-mention!
   "Add a single mention to the parse-map with index."
   [^Mention mention index parse-map]
-  (let [mention-parse (.getParse (.getParse mention))]
+  (let [mention-parse (.getParse ^DefaultParse (.getParse mention))]
     (swap! parse-map assoc mention-parse (+ index 1))))
 
 

--- a/src/opennlp/treebank.clj
+++ b/src/opennlp/treebank.clj
@@ -6,13 +6,15 @@
         [clojure.java.io :only [input-stream]])
   (:require [clojure.string :as str]
             [instaparse.core :as insta])
-  (:import (opennlp.tools.chunker ChunkerModel ChunkerME)
+  (:import (java.util List)
+           (opennlp.tools.chunker ChunkerModel ChunkerME)
            (opennlp.tools.cmdline.parser ParserTool)
            (opennlp.tools.parser Parse ParserModel
                                  ParserFactory AbstractBottomUpParser)
            (opennlp.tools.parser.chunking Parser)
            (opennlp.tools.coref.mention Mention DefaultParse)
-           (opennlp.tools.coref LinkerMode DefaultLinker)))
+           (opennlp.tools.coref LinkerMode DefaultLinker)
+           (opennlp.tools.util Span)))
 
 ;; Default advance percentage as defined by
 ;; AbstractBottomUpParser.defaultAdvancePercentage
@@ -23,7 +25,7 @@
   [chunks]
   (let [seqnum    (atom 0)
         splitfunc (fn
-                    [item]
+                    [^String item]
                     (if (.startsWith item "B-")
                       (swap! seqnum inc)
                       @seqnum))]
@@ -68,12 +70,12 @@
     (make-treebank-chunker (ChunkerModel. modelstream))))
 
 (defmethod make-treebank-chunker ChunkerModel
-  [model]
+  [^ChunkerModel model]
   (fn treebank-chunker
     [pos-tagged-tokens]
-    (let [chunker (ChunkerME. model *beam-size*)
+    (let [chunker (ChunkerME. model (int *beam-size*))
           [tokens tags] (de-interleave pos-tagged-tokens)
-          chunks  (into [] (seq (.chunk chunker tokens tags)))
+          chunks  (into [] (seq (.chunk chunker ^List tokens ^List tags)))
           sized-chunks (map size-chunk (split-chunks chunks))
           [types sizes] (de-interleave sized-chunks)
           token-chunks (split-with-size sizes tokens)
@@ -195,7 +197,7 @@
 (defn print-child
   "Given a child, parent and start, print out the child parse."
   [c p start]
-  (let [s (.getSpan c)]
+  (let [^Span s (.getSpan c)]
     (if (< @start (.getStart s))
       (print (subs (.getText p) start (.getStart s))))
     (print-parse c)
@@ -204,8 +206,8 @@
 ;; This is broken, don't use this.
 (defn print-parse
   "Given a parse and the EntityMentions-to-parse map, print out the parse."
-  [p parse-map]
-  (let [start (atom (.getStart (.getSpan p)))
+  [^Parse p parse-map]
+  (let [start (atom (.getStart ^Span (.getSpan p)))
         children (.getChildren p)]
     (if-not (= Parser/TOK_NODE (.getType p))
       (do
@@ -222,7 +224,7 @@
 
 (defn add-mention!
   "Add a single mention to the parse-map with index."
-  [mention index parse-map]
+  [^Mention mention index parse-map]
   (let [mention-parse (.getParse (.getParse mention))]
     (swap! parse-map assoc mention-parse (+ index 1))))
 
@@ -256,17 +258,17 @@
 
 
 (defn coref-extent
-  [extent p index]
+  [^Mention extent ^Parse p index]
   (if (nil? extent)
-    (let [snp (Parse. (.getText p) (.getSpan extent) "NML" 1.0 0)]
+    (let [snp (Parse. (.getText p) (.getSpan extent) "NML" (double 1.0) (int 0))]
       (.insert p snp) ; FIXME
       (.setParse extent (DefaultParse. snp index)))
     nil))
 
 
 (defn coref-sentence
-  [sentence parses index tblinker]
-  (let [p (Parse/parseParse sentence)
+  [^String sentence parses index ^DefaultLinker tblinker]
+  (let [^Parse p (Parse/parseParse sentence)
         extents (.getMentions (.getMentionFinder tblinker)
                               (DefaultParse. p index))]
     (swap! parses #(assoc % (count %) p))
@@ -278,12 +280,12 @@
 (defn parse-extent
   "Given an coref extent, a treebank linker, a parses atom and the index of
   the extent, return a tuple of the coresponding parse and discourse entities"
-  [extent tblinker parses pindex]
+  [extent ^DefaultLinker tblinker parses pindex]
   (println :ext (bean extent))
   (let [e (filter #(not (nil? (:parse (bean %)))) extent)
         ;;_ (println :e e)
         mention-array (into-array Mention e)
-        entities (.getEntities tblinker mention-array)]
+        entities (.getEntities tblinker #^"[Lopennlp.tools.coref.mention.Mention;" mention-array)]
     (println :entities (seq entities) (bean (first entities)))
     [(get @parses pindex) (seq entities)]))
 


### PR DESCRIPTION
This PR contains two general changes:

e3562f5

- Use final Clojure 1.7.0 version.
- Add Clojure version 1.8.0.
- Update instaparse to 1.4.1. <- This should help to improve the situation related to #40

The remaining commits 30c8844 d9759c9 c897ffb add more type hints in order to avoid reflection warnings with the aim on improving the performance.

Edit: For testing, you can also get a build of this snapshot version from Clojars: [rgad/clojure-opennlp "0.3.4-SNAPSHOT"]