### PR TITLE
OpenNLP 1.7 update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.apache.opennlp/opennlp-tools "1.5.3"]
+  :dependencies [[org.apache.opennlp/opennlp-tools "1.7.0"]
                  [instaparse "1.4.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]
                    :plugins [[lein-marginalia "0.8.0"]]}

--- a/src/opennlp/nlp.clj
+++ b/src/opennlp/nlp.clj
@@ -18,13 +18,6 @@
                            TokenizerModel)
    (opennlp.tools.util Span)))
 
-;; OpenNLP property for pos-tagging. Meant to be rebound before
-;; calling the tagging creators
-(def ^:dynamic *beam-size* (int 3))
-
-;; Caching to use for pos-tagging
-(def ^:dynamic *cache-size* (int 1024))
-
 (defn- opennlp-span-strings
   "Takes a collection of spans and the data they refer to. Returns a list of
   substrings corresponding to spans."
@@ -108,7 +101,7 @@ start and end positions of the span."
     [tokens]
     {:pre [(coll? tokens)]}
     (let [token-array (into-array String tokens)
-          tagger (POSTaggerME. model ^int *beam-size* ^int *cache-size*)
+          tagger (POSTaggerME. model)
           tags (.tag tagger #^"[Ljava.lang.String;" token-array)
           probs (seq (.probs tagger))]
       (with-meta
@@ -126,15 +119,12 @@ start and end positions of the span."
     (make-name-finder (TokenNameFinderModel. model-stream))))
 
 (defmethod make-name-finder TokenNameFinderModel
-  [^TokenNameFinderModel model & {:keys [feature-generator beam] :or {beam *beam-size*}}]
+  [^TokenNameFinderModel model]
   (fn name-finder
     [tokens & contexts]
     {:pre [(seq tokens)
            (every? string? tokens)]}
-    (let [finder (NameFinderME.
-                   model
-                   ^opennlp.tools.util.featuregen.AdaptiveFeatureGenerator feature-generator
-                   (int beam))
+    (let [finder (NameFinderME. model)
           a-tokens (into-array String tokens)
           matches (.find finder a-tokens)
           probs (seq (.probs finder))]

--- a/src/opennlp/tools/train.clj
+++ b/src/opennlp/tools/train.clj
@@ -1,6 +1,6 @@
 (ns opennlp.tools.train
   "This namespace contains tools used to train OpenNLP models"
-  (:use [clojure.java.io :only [output-stream reader input-stream]])
+  (:use [clojure.java.io :only [reader file input-stream output-stream]])
   (:import (opennlp.tools.util PlainTextByLineStream 
                                TrainingParameters
                                MarkableFileInputStreamFactory)
@@ -15,8 +15,7 @@
                                      SentenceModel
                                      SentenceSampleStream
                                      SentenceDetectorFactory)
-           (opennlp.tools.namefind NameFinderEventStream
-                                   NameSampleDataStream
+           (opennlp.tools.namefind NameSampleDataStream
                                    NameFinderME
                                    TokenNameFinderModel
                                    TokenNameFinderFactory
@@ -69,11 +68,11 @@
       lang
       (ChunkSampleStream.
         (PlainTextByLineStream. 
-          (MarkableFileInputStreamFactory. in) "UTF-8"))
-      (ChunkerFactory.)
+          (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
       (doto (TrainingParameters.)
         (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
-        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut))))))
+        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))
+      (ChunkerFactory.))))
 
 (defn ^ParserModel train-treebank-parser
   "Returns a treebank parser based a training file and a set of head rules"
@@ -85,7 +84,7 @@
         lang
         (ParseSampleStream.
          (PlainTextByLineStream.
-          (MarkableFileInputStreamFactory. in) "UTF-8"))
+          (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
         (HeadRules. rdr) 
         (doto (TrainingParameters.)
           (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
@@ -110,7 +109,7 @@
       entity-type
       (NameSampleDataStream.
         (PlainTextByLineStream.
-          (MarkableFileInputStreamFactory. in) "UTF-8"))
+          (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
       (doto (TrainingParameters.)
         (.put TrainingParameters/ALGORITHM_PARAM classifier)
         (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
@@ -126,7 +125,7 @@
     (TokenizerME/train
       (TokenSampleStream.
         (PlainTextByLineStream.
-          (MarkableFileInputStreamFactory. in) "UTF-8"))
+          (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
       (TokenizerFactory. 
         lang nil false nil)
       (doto (TrainingParameters.)
@@ -143,11 +142,11 @@
       lang
       (WordTagSampleStream. 
         (PlainTextByLineStream.
-          (MarkableFileInputStreamFactory. in) "UTF-8"))
-      (POSTaggerFactory. nil tagdict)
+          (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
       (doto (TrainingParameters.)
         (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
-        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut))))))
+        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))
+      (POSTaggerFactory. nil tagdict))))
 
 (defn ^SentenceModel train-sentence-detector
   "Returns a sentence model based on a given training file"
@@ -157,7 +156,7 @@
       lang
       (SentenceSampleStream. 
         (PlainTextByLineStream.
-          (MarkableFileInputStreamFactory. in) "UTF-8"))
+          (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
       (SentenceDetectorFactory. lang true nil nil)
       (TrainingParameters.))))
 
@@ -171,7 +170,7 @@
          lang
          (DocumentSampleStream.
            (PlainTextByLineStream.
-             (MarkableFileInputStreamFactory. in) "UTF-8"))
+             (MarkableFileInputStreamFactory. (file in)) "UTF-8"))
          (doto (TrainingParameters.)
            (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
            (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))

--- a/src/opennlp/tools/train.clj
+++ b/src/opennlp/tools/train.clj
@@ -1,31 +1,43 @@
 (ns opennlp.tools.train
   "This namespace contains tools used to train OpenNLP models"
   (:use [clojure.java.io :only [output-stream reader input-stream]])
-  (:import (opennlp.tools.util PlainTextByLineStream TrainingParameters)
-           (opennlp.tools.util.model BaseModel ModelType)
+  (:import (opennlp.tools.util PlainTextByLineStream 
+                               TrainingParameters
+                               MarkableFileInputStreamFactory)
+           (opennlp.tools.util.model BaseModel 
+                                     ModelType)
            (opennlp.tools.dictionary Dictionary)
            (opennlp.tools.tokenize TokenizerME
                                    TokenizerModel
-                                   TokenSampleStream)
+                                   TokenSampleStream
+                                   TokenizerFactory)
            (opennlp.tools.sentdetect SentenceDetectorME
                                      SentenceModel
-                                     SentenceSampleStream)
+                                     SentenceSampleStream
+                                     SentenceDetectorFactory)
            (opennlp.tools.namefind NameFinderEventStream
                                    NameSampleDataStream
                                    NameFinderME
-                                   TokenNameFinderModel)
-           (opennlp.tools.chunker ChunkerME ChunkSampleStream ChunkerModel)
-           (opennlp.tools.parser ParseSampleStream ParserModel)
+                                   TokenNameFinderModel
+                                   TokenNameFinderFactory
+                                   BioCodec)
+           (opennlp.tools.chunker ChunkerME 
+                                  ChunkSampleStream 
+                                  ChunkerModel
+                                  ChunkerFactory)
+           (opennlp.tools.parser ParseSampleStream 
+                                 ParserModel)
            (opennlp.tools.parser.lang.en HeadRules)
            (opennlp.tools.parser.chunking Parser)
            (opennlp.tools.postag POSTaggerME
                                  POSModel
                                  POSDictionary
                                  WordTagSampleStream
-                                 POSContextGenerator)
+                                 POSTaggerFactory)
            (opennlp.tools.doccat DoccatModel
                                  DocumentCategorizerME
-                                 DocumentSampleStream)))
+                                 DocumentSampleStream
+                                 DoccatFactory)))
 
 (defn write-model
   "Write a model to disk"
@@ -53,26 +65,31 @@
   ([in] (train-treebank-chunker "en" in))
   ([lang in] (train-treebank-chunker lang in 100 5))
   ([lang in iter cut]
-     (with-open [rdr (reader in)]
-       (ChunkerME/train
-        lang
-        (ChunkSampleStream.
-         (PlainTextByLineStream. rdr))
-        cut iter))))
+    (ChunkerME/train
+      lang
+      (ChunkSampleStream.
+        (PlainTextByLineStream. 
+          (MarkableFileInputStreamFactory. in) "UTF-8"))
+      (ChunkerFactory.)
+      (doto (TrainingParameters.)
+        (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
+        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut))))))
 
 (defn ^ParserModel train-treebank-parser
   "Returns a treebank parser based a training file and a set of head rules"
   ([in headrules] (train-treebank-parser "en" in headrules))
   ([lang in headrules] (train-treebank-parser lang in headrules 100 5))
   ([lang in headrules iter cut]
-     (with-open [rdr (reader headrules)
-                 fis (java.io.FileInputStream. in)]
+     (with-open [rdr (reader headrules)]
        (Parser/train
         lang
         (ParseSampleStream.
          (PlainTextByLineStream.
-          (.getChannel fis) "UTF-8"))
-        (HeadRules. rdr) iter cut))))
+          (MarkableFileInputStreamFactory. in) "UTF-8"))
+        (HeadRules. rdr) 
+        (doto (TrainingParameters.)
+          (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
+          (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))))))
 
 
 (defn ^TokenNameFinderModel train-name-finder
@@ -87,33 +104,34 @@
   ([lang in iter cut & {:keys [entity-type feature-gen classifier]
                         ;;MUST be either "MAXENT" or "PERCEPTRON"
                         :or  {entity-type "default" classifier "MAXENT"}}]
-     (with-open [rdr (reader in)]
-       (NameFinderME/train
-        lang
-        entity-type
-        (->> rdr
-             (PlainTextByLineStream.)
-             (NameSampleDataStream.))
-        (doto (TrainingParameters.)
-          (.put TrainingParameters/ALGORITHM_PARAM classifier)
-          (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
-          (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))
-        feature-gen {}))))
+    
+    (NameFinderME/train
+      lang
+      entity-type
+      (NameSampleDataStream.
+        (PlainTextByLineStream.
+          (MarkableFileInputStreamFactory. in) "UTF-8"))
+      (doto (TrainingParameters.)
+        (.put TrainingParameters/ALGORITHM_PARAM classifier)
+        (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
+        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))
+      (TokenNameFinderFactory. 
+        feature-gen {} (BioCodec.)))))
 
 (defn ^TokenizerModel train-tokenizer
   "Returns a tokenizer based on given training file"
   ([in] (train-tokenizer "en" in))
   ([lang in] (train-tokenizer lang in 100 5))
   ([lang in iter cut]
-     (with-open [rdr (reader in)]
-       (TokenizerME/train
-        lang
-        (->> rdr
-             (PlainTextByLineStream.)
-             (TokenSampleStream.))
-        false
-        cut
-        iter))))
+    (TokenizerME/train
+      (TokenSampleStream.
+        (PlainTextByLineStream.
+          (MarkableFileInputStreamFactory. in) "UTF-8"))
+      (TokenizerFactory. 
+        lang nil false nil)
+      (doto (TrainingParameters.)
+        (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
+        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut))))))
 
 (defn ^POSModel train-pos-tagger
   "Returns a pos-tagger based on given training file"
@@ -121,37 +139,41 @@
   ([lang in] (train-pos-tagger lang in nil))
   ([lang in tagdict] (train-pos-tagger lang in tagdict 100 5))
   ([lang in tagdict iter cut]
-     (with-open [rdr (reader in)]
-       (POSTaggerME/train
-        lang
-        (WordTagSampleStream. rdr)
-        (ModelType/MAXENT)
-        tagdict
-        nil
-        cut
-        iter))))
+    (POSTaggerME/train
+      lang
+      (WordTagSampleStream. 
+        (PlainTextByLineStream.
+          (MarkableFileInputStreamFactory. in) "UTF-8"))
+      (POSTaggerFactory. nil tagdict)
+      (doto (TrainingParameters.)
+        (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
+        (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut))))))
 
 (defn ^SentenceModel train-sentence-detector
   "Returns a sentence model based on a given training file"
   ([in] (train-sentence-detector "en" in))
   ([lang in]
-     (with-open [rdr (reader in)]
-       (SentenceDetectorME/train lang
-                                 (->> rdr
-                                      (PlainTextByLineStream.)
-                                      (SentenceSampleStream.))
-                                 true
-                                 nil))))
+    (SentenceDetectorME/train 
+      lang
+      (SentenceSampleStream. 
+        (PlainTextByLineStream.
+          (MarkableFileInputStreamFactory. in) "UTF-8"))
+      (SentenceDetectorFactory. lang true nil nil)
+      (TrainingParameters.))))
 
 (defn ^DoccatModel train-document-categorization
   "Returns a classification model based on a given training file"
   ([in] (train-document-categorization "en" in 1 100))
   ([lang in] (train-document-categorization lang in 1 100))
-  ([lang in cutoff] (train-document-categorization lang in cutoff 100))
-  ([lang in cutoff iterations]
-     (with-open [rdr (reader in)]
-       (DocumentCategorizerME/train lang
-                                    (->> rdr
-                                         (PlainTextByLineStream.)
-                                         (DocumentSampleStream.))
-                                    cutoff iterations))))
+  ([lang in cut] (train-document-categorization lang in cut 100))
+  ([lang in cut iter]
+       (DocumentCategorizerME/train 
+         lang
+         (DocumentSampleStream.
+           (PlainTextByLineStream.
+             (MarkableFileInputStreamFactory. in) "UTF-8"))
+         (doto (TrainingParameters.)
+           (.put TrainingParameters/ITERATIONS_PARAM (Integer/toString iter))
+           (.put TrainingParameters/CUTOFF_PARAM     (Integer/toString cut)))
+         (DoccatFactory.))))
+                                   

--- a/src/opennlp/treebank.clj
+++ b/src/opennlp/treebank.clj
@@ -74,7 +74,9 @@
     [pos-tagged-tokens]
     (let [chunker (ChunkerME. model)
           [tokens tags] (de-interleave pos-tagged-tokens)
-          chunks  (into [] (seq (.chunk chunker ^List tokens ^List tags)))
+          chunks  (into [] (seq (.chunk chunker 
+                                  (into-array ^List tokens) 
+                                  (into-array ^List tags))))
           sized-chunks (map size-chunk (split-chunks chunks))
           [types sizes] (de-interleave sized-chunks)
           token-chunks (split-with-size sizes tokens)

--- a/src/opennlp/treebank.clj
+++ b/src/opennlp/treebank.clj
@@ -2,8 +2,7 @@
              This includes treebank chuncking, parsing and linking (coref)."
        :author "Lee Hinman"}
   opennlp.treebank
-  (:use [opennlp.nlp :only [*beam-size*]]
-        [clojure.java.io :only [input-stream]])
+  (:use [clojure.java.io :only [input-stream]])
   (:require [clojure.string :as str]
             [instaparse.core :as insta])
   (:import (java.util List)
@@ -12,13 +11,13 @@
            (opennlp.tools.parser Parse ParserModel
                                  ParserFactory AbstractBottomUpParser)
            (opennlp.tools.parser.chunking Parser)
-           (opennlp.tools.coref.mention Mention DefaultParse)
-           (opennlp.tools.coref LinkerMode DefaultLinker)
            (opennlp.tools.util Span)))
 
 ;; Default advance percentage as defined by
 ;; AbstractBottomUpParser.defaultAdvancePercentage
 (def ^:dynamic *advance-percentage* 0.95)
+
+(def ^:dynamic *beam-size* 3)
 
 (defn- split-chunks
   "Partition a sequence of treebank chunks by their phrases."
@@ -73,7 +72,7 @@
   [^ChunkerModel model]
   (fn treebank-chunker
     [pos-tagged-tokens]
-    (let [chunker (ChunkerME. model (int *beam-size*))
+    (let [chunker (ChunkerME. model)
           [tokens tags] (de-interleave pos-tagged-tokens)
           chunks  (into [] (seq (.chunk chunker ^List tokens ^List tags)))
           sized-chunks (map size-chunk (split-chunks chunks))
@@ -187,138 +186,3 @@
   [tree-text & [tag-fn]]
   (tr (s-parser tree-text) tag-fn))
 
-;;------------------------------------------------------------------------
-;;------------------------------------------------------------------------
-;; Treebank Linking
-;; WIP, do not use yet.
-
-(declare print-parse)
-
-(defn print-child
-  "Given a child, parent and start, print out the child parse."
-  [^Parse c ^Parse p start]
-  (let [s (.getSpan c)]
-    (if (< @start (.getStart s))
-      (print (subs (.getText p) start (.getStart s))))
-    (print-parse c)
-    (reset! start (.getEnd s))))
-
-;; This is broken, don't use this.
-(defn print-parse
-  "Given a parse and the EntityMentions-to-parse map, print out the parse."
-  [^Parse p parse-map]
-  (let [start (atom (.getStart ^Span (.getSpan p)))
-        children (.getChildren p)]
-    (if-not (= Parser/TOK_NODE (.getType p))
-      (do
-        (print (str "(" (.getType p)))
-        (if (contains? parse-map p)
-          (print (str "#" (get parse-map p))))
-        (print " ")))
-    (map #(print-child % p start) children)
-    ;; FIXME: don't use substring
-    (print (subs (.getText p) @start (.getEnd (.getSpan p))))
-    (if-not (= Parser/TOK_NODE (.getType p))
-      (print ")"))))
-
-
-(defn add-mention!
-  "Add a single mention to the parse-map with index."
-  [^Mention mention index parse-map]
-  (let [mention-parse (.getParse ^DefaultParse (.getParse mention))]
-    (swap! parse-map assoc mention-parse (+ index 1))))
-
-
-(defn add-mentions!
-  "Add mentions to the parse map."
-  [entity index parse-map]
-  (dorun (map #(add-mention! % index parse-map)
-              (iterator-seq (.getMentions entity)))))
-
-
-(defn add-entities
-  "Given a list of entities, return a map of parses to entities."
-  [entities]
-  (let [parse-map (atom {})
-        i-entities (map vector (iterate inc 0) entities)]
-    (dorun (map (fn [[index entity]] (add-mentions! entity index parse-map))
-                i-entities))
-    @parse-map))
-
-
-;; This is intended to actually be called.
-(defn show-parses
-  "Given a list of parses and entities, print them out."
-  [parse entities]
-  (let [parse-map (add-entities entities)]
-    (println "parse-map:" parse-map)
-    (println "parse:" parse)
-    (print-parse parse parse-map)
-    parse-map))
-
-
-(defn coref-extent
-  [^Mention extent ^Parse p index]
-  (if (nil? extent)
-    (let [snp (Parse. (.getText p) (.getSpan extent) "NML" (double 1.0) (int 0))]
-      (.insert p snp) ; FIXME
-      (.setParse extent (DefaultParse. snp index)))
-    nil))
-
-
-(defn coref-sentence
-  [^String sentence parses index ^DefaultLinker tblinker]
-  (let [^Parse p (Parse/parseParse sentence)
-        extents (.getMentions (.getMentionFinder tblinker)
-                              (DefaultParse. p index))]
-    (swap! parses #(assoc % (count %) p))
-    (map #(coref-extent % p index) extents)
-    ;;(println :es (map #(println (bean %)) extents))
-    (map bean extents)))
-
-;; TODO: fix this function, currently doesn't parse correctly
-(defn parse-extent
-  "Given an coref extent, a treebank linker, a parses atom and the index of
-  the extent, return a tuple of the coresponding parse and discourse entities"
-  [extent ^DefaultLinker tblinker parses pindex]
-  (println :ext (bean extent))
-  (let [e (filter #(not (nil? (:parse (bean %)))) extent)
-        ;;_ (println :e e)
-        mention-array (into-array Mention e)
-        entities (.getEntities tblinker #^"[Lopennlp.tools.coref.mention.Mention;" mention-array)]
-    (println :entities (seq entities) (bean (first entities)))
-    [(get @parses pindex) (seq entities)]))
-
-;; Second Attempt
-(defn make-treebank-linker
-  "Make a TreebankLinker, given a model directory."
-  [modeldir]
-  (let [tblinker (DefaultLinker. modeldir LinkerMode/TEST)]
-    (fn treebank-linker
-      [sentences]
-      (let [parses (atom [])
-            indexed-sentences (map vector (iterate inc 0) sentences)
-            extents (doall (map #(coref-sentence (second %) parses
-                                                 (first %) tblinker)
-                                indexed-sentences))
-            i-extents (map vector (iterate inc 0) extents)]
-        #_(map #(parse-extent %1 tblinker parses %2) i-extents)
-        (doall (map println extents))
-        extents))))
-
-;; this is used for the treebank linking, it is a system property for
-;; the location of the wordnet installation 'dict' directory
-;; see: http://wordnet.princeton.edu/wordnet/
-(defn set-wordnet-location!
-  "Set the location of the WordNet 'dict' directory"
-  [location]
-  (System/setProperty "WNSEARCHDIR" location))
-
-;;  What I really need is a good way to express this in Clojure's datastructures.
-(comment
-  (def tbl (make-treebank-linker "coref"))
-  (def treebank-parser
-    (make-treebank-parser "parser-model/en-parser-chunking.bin"))
-  (def s (treebank-parser ["Mary said she liked me ."]))
-  (tbl s)
-  )

--- a/test/opennlp/test/tools/train.clj
+++ b/test/opennlp/test/tools/train.clj
@@ -65,7 +65,7 @@
         parser (tb/make-treebank-parser tb-parser-model)]
     (is (= (parser ["This is a sentence ."])
            [(str "(INC (NP (DT This)) (NP (DT is)) (NP (DT a))"
-                 " (DT sentence) (. .))")]))))
+                 " (DT sentence) (. .) )")]))))
 
 (deftest write-out-training-model-test
   (let [token-model (train/train-tokenizer "training/tokenizer.train")

--- a/test/opennlp/test/treebank.clj
+++ b/test/opennlp/test/treebank.clj
@@ -28,7 +28,7 @@
     (let [parser (make-treebank-parser "parser-model/en-parser-chunking.bin")]
       (is (= (parser ["This is a sentence ."])
              [(str "(TOP (S (NP (DT This)) (VP (VBZ is) (NP (DT a)"
-                   " (NN sentence))) (. .)))")]))
+                   " (NN sentence))) (. .) ))")]))
       (is (= (make-tree (first (parser ["This is a sentence ."])))
              '{:tag TOP
                :chunk (
@@ -50,7 +50,7 @@
   (try
     (let [parser (make-treebank-parser "parser-model/en-parser-chunking.bin")]
       (is (= (parser ["2:30 isn't bad"])
-             ["(TOP (NP (CD 2:30) (RB isn't) (JJ bad)))"]))
+             ["(TOP (NP (CD 2:30) (RB isn't) (JJ bad)) )"]))
       (is (= (make-tree (first (parser ["2:30 isn't bad"])))
              '{:tag TOP,
                :chunk ({:tag NP,


### PR DESCRIPTION
The new OpenNLP removed a bunch of deprecated material, so I patched up your excellent library so that it works with the latest release. 

This was a very bare-bones update: I merely got everything to compile and made sure all the tests pass.  

Note that I had to remove the speculative code you had for linking, since the coref component is now gone from OpenNLP.

Another note: OpenNLP now requires Java 8.  The Travis CI job will fail unless it uses JDK 1.8.